### PR TITLE
Update node-jsonwebtoken deps to fix a critical vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "url": "http://www.opensource.org/licenses/MIT"
   },
   "dependencies": {
-    "jsonwebtoken": "^1.2.0",
+    "jsonwebtoken": "^4.2.2",
     "passport-http-bearer": "^1.0.1"
   },
   "devDependencies": {

--- a/test/strategy.normal.js
+++ b/test/strategy.normal.js
@@ -159,7 +159,7 @@ describe('Strategy', function() {
       chai.passport.use(new Strategy(secret, {audience: 'foo'}, function(token, done) { done(null, false)}))
         .fail(function(challenge) {;
           expect(challenge).to.be.a.string;
-          expect(challenge).to.equal('Bearer realm="Users", error="invalid_token", error_description="Invalid token (jwt audience invalid. expected: bar)"');
+          expect(challenge).to.equal('Bearer realm="Users", error="invalid_token", error_description="Invalid token (jwt audience invalid. expected: foo)"');
           done();
         })
         .req(function(req) {
@@ -172,7 +172,7 @@ describe('Strategy', function() {
       chai.passport.use(new Strategy(secret, {issuer: 'foo'}, function(token, done) { done(null, false)}))
         .fail(function(challenge) {;
           expect(challenge).to.be.a.string;
-          expect(challenge).to.equal('Bearer realm="Users", error="invalid_token", error_description="Invalid token (jwt issuer invalid. expected: bar)"');
+          expect(challenge).to.equal('Bearer realm="Users", error="invalid_token", error_description="Invalid token (jwt issuer invalid. expected: foo)"');
           done();
         })
         .req(function(req) {


### PR DESCRIPTION
Write-up of the vulnerability in question: https://auth0.com/blog/2015/03/31/critical-vulnerabilities-in-json-web-token-libraries/

This library is a few major versions behind so I'm a little paranoid but the tests still pass (after one fix, details in commit). I've also tested this branch on my own project and I'm still signing and authorising valid tokens.
